### PR TITLE
Fixed ordered list

### DIFF
--- a/content/installation/linux.md
+++ b/content/installation/linux.md
@@ -16,32 +16,32 @@ Here are the instruction for [installation on Ubuntu 16.10](https://docs.google.
 
 1. Install wine:
 
-```bash
-sudo apt-get install wine
-```
+    ```bash
+    sudo apt-get install wine
+    ```
 
 2. Download the offline bundle named like Balsamiq_Mockups_3.x.y_bundled.zip and install it in /opt:
 
-```bash
-sudo unzip Downloads/Balsamiq_Mockups_3.x.y_bundled.zip -d /opt
-sudo mv /opt/Balsamiq_Mockups_3 /opt/balsamiq_3_x_y
-sudo rm -f /opt/balsamiq && sudo ln -s /opt/balsamiq_3_x_y /opt/balsamiq
-sudo mv /opt/balsamiq/Balsamiq\ Mockups\ 3.exe /opt/balsamiq/balsamiq.exe
-
-# This Should Now Work
-wine /opt/balsamiq/balsamiq.exe
-```
+    ```bash
+    sudo unzip Downloads/Balsamiq_Mockups_3.x.y_bundled.zip -d /opt
+    sudo mv /opt/Balsamiq_Mockups_3 /opt/balsamiq_3_x_y
+    sudo rm -f /opt/balsamiq && sudo ln -s /opt/balsamiq_3_x_y /opt/balsamiq
+    sudo mv /opt/balsamiq/Balsamiq\ Mockups\ 3.exe /opt/balsamiq/balsamiq.exe
+    
+    # This Should Now Work
+    wine /opt/balsamiq/balsamiq.exe
+    ```
 
 3. Add a startup icon:
 
-```bash
-echo '[Desktop Entry]
-Encoding=UTF-8
-Name=Balsamiq Mockups
-Icon=/opt/balsamiq/icons/mockups_ico_48.png
-Exec=wine /opt/balsamiq/balsamiq.exe
-Type=Application
-Categories=Graphics;
-MimeType=application/x-xdg-protocol-tg;x-scheme-handler/tg;
-' |sudo tee /usr/share/applications/balsamiq.desktop
-```
+    ```bash
+    echo '[Desktop Entry]
+    Encoding=UTF-8
+    Name=Balsamiq Mockups
+    Icon=/opt/balsamiq/icons/mockups_ico_48.png
+    Exec=wine /opt/balsamiq/balsamiq.exe
+    Type=Application
+    Categories=Graphics;
+    MimeType=application/x-xdg-protocol-tg;x-scheme-handler/tg;
+    ' |sudo tee /usr/share/applications/balsamiq.desktop
+    ```


### PR DESCRIPTION
While Github markdown presents the ordered list with
the correct numbers (1, 2, 3), HUGO markdown parser
doesn't allow ordered list starting on arbitrary numbers,
like GH does.

I'm unsure which parser HUGO uses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/balsamiq/support.balsamiq.com/103)
<!-- Reviewable:end -->
